### PR TITLE
feat: prompt creation page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8649,6 +8649,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.1.tgz",
+      "integrity": "sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10022,6 +10031,7 @@
         "next": "15.1.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.1",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7"
       },

--- a/web/app/api/prompts/route.ts
+++ b/web/app/api/prompts/route.ts
@@ -1,0 +1,67 @@
+import { createClient } from "@supabase/supabase-js"
+import { Database } from "@/database.types"
+import { NextResponse } from "next/server"
+
+// Initialize Supabase client with server-side credentials
+const supabase = createClient<Database>(
+  process.env.SUPABASE_URL ?? "",
+  process.env.SUPABASE_ANON_KEY ?? ""
+)
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const { name, template, version, templateVariables } = body
+
+    // Validation
+    if (!name || !template || !version) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 }
+      )
+    }
+
+    // First, create the prompt
+    const { data: promptData, error: promptError } = await supabase
+      .from("prompts")
+      .insert([{ name, template }])
+      .select("id")
+      .single()
+
+    if (promptError) {
+      console.error("Error creating prompt:", promptError)
+      return NextResponse.json(
+        { error: "Failed to create prompt" },
+        { status: 500 }
+      )
+    }
+
+    // Then create the prompt version
+    const { error: versionError } = await supabase
+      .from("prompt_version")
+      .insert([
+        {
+          prompt: template,
+          template_variables: templateVariables,
+          prompt_id: promptData.id,
+          version,
+        },
+      ])
+
+    if (versionError) {
+      console.error("Error creating prompt version:", versionError)
+      return NextResponse.json(
+        { error: "Failed to create prompt version" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true, id: promptData.id })
+  } catch (error) {
+    console.error("Unexpected error:", error)
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    )
+  }
+}

--- a/web/app/fonts.ts
+++ b/web/app/fonts.ts
@@ -1,0 +1,13 @@
+import { DM_Mono, Merriweather } from "next/font/google"
+
+export const dmMono = DM_Mono({
+  weight: ["400", "500"],
+  subsets: ["latin"],
+  variable: "--font-dm-mono",
+})
+
+export const merriweather = Merriweather({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-merriweather",
+})

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 import Header from "@/components/Header"
 import Sidebar from "@/components/Sidebar"
+import { dmMono, merriweather } from "./fonts"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,10 +26,11 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable} ${dmMono.variable} ${merriweather.variable} antialiased`}
+    >
+      <body>
         <div className="min-h-screen flex flex-col">
           <div className="flex-1 flex">
             <Sidebar />

--- a/web/app/prompts/new/page.client.tsx
+++ b/web/app/prompts/new/page.client.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import React, { useState } from "react"
+import { useRouter } from "next/navigation"
+import { merriweather } from "@/app/fonts"
+import Link from "next/link"
+import { Play, X } from "lucide-react"
+
+const NewPromptClient = () => {
+  const router = useRouter()
+  const [promptName, setPromptName] = useState<string>("Untitled")
+  const [version, setVersion] = useState<string>("0.0.1")
+  const [template, setTemplate] = useState<string>("")
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [errors, setErrors] = useState<{
+    name?: string
+    version?: string
+    template?: string
+    general?: string
+  }>({})
+
+  // Extract template variables from the template
+  const extractTemplateVariables = (templateText: string): string[] => {
+    const regex = /{{([^{}]+)}}/g
+    const matches = [...templateText.matchAll(regex)]
+    const variables = matches.map((match) => match[1].trim())
+    // Remove duplicates
+    return [...new Set(variables)]
+  }
+
+  // Validate form fields
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {}
+
+    if (!promptName || promptName.trim() === "") {
+      newErrors.name = "Prompt name is required"
+    }
+
+    if (!version || !version.match(/^\d+\.\d+\.\d+$/)) {
+      newErrors.version = "Version must be in format x.y.z (e.g. 0.0.1)"
+    }
+
+    if (!template || template.trim() === "") {
+      newErrors.template = "Template is required"
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async () => {
+    if (!validateForm()) {
+      return
+    }
+
+    setIsLoading(true)
+
+    try {
+      // Extract template variables
+      const templateVariables = extractTemplateVariables(template)
+
+      // Call our API route instead of Supabase directly
+      const response = await fetch("/api/prompts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: promptName,
+          template,
+          version,
+          templateVariables,
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to save prompt")
+      }
+
+      // Navigate back to prompts page on success
+      router.push("/prompts")
+    } catch (error) {
+      console.error("Error saving prompt:", error)
+      setErrors({
+        general:
+          error instanceof Error
+            ? error.message
+            : "Failed to save prompt. Please try again.",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleRun = async () => {
+    // TODO: Implement run functionality
+    console.log("Running prompt:", { name: promptName, version, template })
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex gap-2 text-2xl font-bold">
+          <p className={`${merriweather.className}`}>New prompt</p>
+          <p className="font-mono">/</p>
+          <p className="font-mono font-normal">{promptName}</p>
+        </div>
+        <div className="flex gap-2 items-center">
+          <button
+            onClick={handleSave}
+            disabled={isLoading}
+            className={`flex items-center gap-2 font-bold ${
+              isLoading
+                ? "bg-gray-400"
+                : "bg-burnt-orange hover:bg-burnt-orange-dark"
+            } text-white px-4 py-2 transition-all duration-300`}
+          >
+            <p className="font-bold">{isLoading ? "Saving..." : "Save"}</p>
+          </button>
+          <Link href="/prompts" className="px-2">
+            <X />
+          </Link>
+        </div>
+      </div>
+
+      {errors.general && (
+        <div className="p-3 mb-4 text-red-700 bg-red-100 border border-red-300 rounded">
+          {errors.general}
+        </div>
+      )}
+
+      <div className="grid grid-cols-3 gap-4 flex-grow">
+        <div className="col-span-2 flex flex-col space-y-4">
+          <div>
+            <div
+              className={`flex border-2 ${
+                errors.name ? "border-red-500" : "border-gray-200"
+              } focus-within:border-burnt-orange focus-within:ring-1 focus-within:ring-burnt-orange`}
+            >
+              <span className="text-burnt-orange py-2 pl-2 pr-1 font-medium min-w-[80px] bg-cream font-dm-mono">
+                Name:
+              </span>
+              <input
+                type="text"
+                value={promptName}
+                onChange={(e) => setPromptName(e.target.value)}
+                className="w-full p-2 outline-none border-none font-dm-mono bg-cream"
+                placeholder="Untitled"
+              />
+            </div>
+            {errors.name && (
+              <p className="text-red-500 text-sm mt-1">{errors.name}</p>
+            )}
+          </div>
+
+          <div>
+            <div
+              className={`flex border-2 ${
+                errors.version ? "border-red-500" : "border-gray-200"
+              } focus-within:border-burnt-orange focus-within:ring-1 focus-within:ring-burnt-orange`}
+            >
+              <span className="text-burnt-orange py-2 pl-2 pr-1 font-medium min-w-[80px] bg-cream font-dm-mono">
+                Version:
+              </span>
+              <input
+                type="text"
+                value={version}
+                onChange={(e) => setVersion(e.target.value)}
+                className="w-full p-2 outline-none border-none font-dm-mono bg-cream"
+                placeholder="e.g. 0.0.1"
+              />
+            </div>
+            {errors.version && (
+              <p className="text-red-500 text-sm mt-1">{errors.version}</p>
+            )}
+          </div>
+
+          <div className="flex flex-col flex-grow">
+            <label className="block mb-1 text-gray-500 font-dm-mono font-medium">
+              Template
+            </label>
+            <div
+              className={`border-2 ${
+                errors.template ? "border-red-500" : "border-gray-200"
+              } focus-within:border-burnt-orange focus-within:ring-1 focus-within:ring-burnt-orange bg-cream`}
+            >
+              <textarea
+                value={template}
+                onChange={(e) => setTemplate(e.target.value)}
+                className="w-full p-2 outline-none border-none font-dm-mono bg-cream resize-y min-h-[200px]"
+                placeholder='e.g. Always respond "hello world". Use {{variable}} for template variables.'
+                rows={10}
+              />
+            </div>
+            {errors.template && (
+              <p className="text-red-500 text-sm mt-1">{errors.template}</p>
+            )}
+
+            {template && (
+              <div className="mt-2">
+                <h3 className="text-sm font-medium text-gray-600">
+                  Template Variables Detected:
+                </h3>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {extractTemplateVariables(template).length > 0 ? (
+                    extractTemplateVariables(template).map((variable, idx) => (
+                      <span
+                        key={idx}
+                        className="px-2 py-1 bg-gray-100 text-gray-700 text-sm rounded-md"
+                      >
+                        {variable}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-sm text-gray-500">
+                      No variables detected. Use {`{{variable_name}}`} syntax.
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="col-span-1 flex flex-col">
+          <div className="mb-2 text-gray-500 font-dm-mono font-medium">
+            Run history
+          </div>
+          <div className="flex flex-col gap-2 border-2 border-dashed border-gray-200 p-4 flex-grow">
+            <div className="flex justify-between items-center">
+              <select className="border-2 border-gray-200 p-1 focus:border-burnt-orange focus:ring-1 focus:ring-burnt-orange outline-none font-dm-mono">
+                <option className="text-gray-400">No runs to show</option>
+              </select>
+              <button
+                onClick={handleRun}
+                className="flex items-center gap-2 font-bold bg-burnt-orange text-white px-4 py-2 hover:bg-burnt-orange-dark transition-all duration-300"
+              >
+                <Play className="w-4 h-4 text-white" fill="white" />
+                <p className="font-bold">Run</p>
+              </button>
+            </div>
+            <div className="border-2 border-dashed border-gray-300 p-4 flex-grow mt-2 flex items-center justify-center text-gray-400">
+              Run results will appear here
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default NewPromptClient

--- a/web/app/prompts/new/page.tsx
+++ b/web/app/prompts/new/page.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import NewPromptClient from "./page.client"
+
+const NewPromptPage = () => {
+  return (
+    <div className="w-full h-full px-8 py-6">
+      <NewPromptClient />
+    </div>
+  )
+}
+
+export default NewPromptPage

--- a/web/app/prompts/page.client.tsx
+++ b/web/app/prompts/page.client.tsx
@@ -4,7 +4,7 @@ import { Merriweather } from "next/font/google"
 import { PromptTemplate } from "@anyprompt/core"
 import PromptCard from "@/components/PromptCard"
 import { Plus } from "lucide-react"
-
+import Link from "next/link"
 interface PromptsPageClientProps {
   prompts: PromptTemplate[]
 }
@@ -23,11 +23,19 @@ export default function PromptsPageClient({ prompts }: PromptsPageClientProps) {
           <p className={`text-xl font-bold`}>·</p>
           <p className={`text-xl`}>{prompts.length}</p>
         </div>
-        <button className="bg-burnt-orange text-white px-3 py-2 flex items-center gap-1 font-semibold">
+        <Link
+          href="/prompts/new"
+          className="bg-burnt-orange text-white px-3 py-2 flex items-center gap-1 font-semibold"
+        >
           <Plus /> New
-        </button>
+        </Link>
       </div>
       <div className="grid grid-cols-2 gap-4 px-8">
+        {prompts.length === 0 && (
+          <div className="border-2 border-dashed border-gray-300 p-4 h-64">
+            <p className="text-gray-500">Create your first prompt</p>
+          </div>
+        )}
         {prompts.map((prompt) => (
           <PromptCard key={prompt.id} prompt={prompt} />
         ))}

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -30,7 +30,9 @@ const Sidebar = (props: Props) => {
         className={`p-2 min-w-[264px] pl-8 ${
           merriweather.className
         } transition-colors duration-300 hover:bg-cream-hover ${
-          pathname === "/prompts" ? "text-burnt-orange bg-cream-hover" : ""
+          pathname === "/prompts" || pathname === "/prompts/new"
+            ? "text-burnt-orange bg-cream-hover"
+            : ""
         }`}
       >
         Prompts

--- a/web/database.types.ts
+++ b/web/database.types.ts
@@ -7,48 +7,149 @@ export type Json =
   | Json[]
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          operationName?: string
-          query?: string
-          variables?: Json
-          extensions?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
-      prompts: {
+      prompt_version: {
         Row: {
           created_at: string
           id: string
-          template: string
+          prompt: string | null
+          prompt_id: string | null
+          template_variables: string[] | null
+          updated_at: string | null
+          version: string | null
         }
         Insert: {
           created_at?: string
-          id: string
-          template: string
+          id?: string
+          prompt?: string | null
+          prompt_id?: string | null
+          template_variables?: string[] | null
+          updated_at?: string | null
+          version?: string | null
         }
         Update: {
           created_at?: string
           id?: string
+          prompt?: string | null
+          prompt_id?: string | null
+          template_variables?: string[] | null
+          updated_at?: string | null
+          version?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prompt_version_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      prompts: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+          template: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+          template: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
           template?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      run_history: {
+        Row: {
+          additional_metadata: Json | null
+          id: string
+          model: string | null
+          prompt_version: string | null
+          run_result: string | null
+          run_timestamp: string
+        }
+        Insert: {
+          additional_metadata?: Json | null
+          id?: string
+          model?: string | null
+          prompt_version?: string | null
+          run_result?: string | null
+          run_timestamp?: string
+        }
+        Update: {
+          additional_metadata?: Json | null
+          id?: string
+          model?: string | null
+          prompt_version?: string | null
+          run_result?: string | null
+          run_timestamp?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "run_history_prompt_version_fkey"
+            columns: ["prompt_version"]
+            isOneToOne: false
+            referencedRelation: "prompt_version"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_api_keys: {
+        Row: {
+          created_at: string | null
+          encrypted_api_key: string
+          id: string
+          provider: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          encrypted_api_key: string
+          id?: string
+          provider: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          encrypted_api_key?: string
+          id?: string
+          provider?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_api_keys_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "Users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      Users: {
+        Row: {
+          email: string
+          id: string
+        }
+        Insert: {
+          email: string
+          id: string
+        }
+        Update: {
+          email?: string
+          id?: string
         }
         Relationships: []
       }
@@ -77,7 +178,7 @@ export type Tables<
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
@@ -86,14 +187,14 @@ export type Tables<
     ? R
     : never
   : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-      PublicSchema["Views"])
-  ? (PublicSchema["Tables"] &
-      PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R
-    }
-    ? R
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
@@ -101,7 +202,7 @@ export type TablesInsert<
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
@@ -109,12 +210,12 @@ export type TablesInsert<
     ? I
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I
-    }
-    ? I
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
@@ -122,7 +223,7 @@ export type TablesUpdate<
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
@@ -130,12 +231,12 @@ export type TablesUpdate<
     ? U
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U
-    }
-    ? U
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never
 
 export type Enums<
   PublicEnumNameOrOptions extends
@@ -143,12 +244,12 @@ export type Enums<
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-  : never
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
@@ -158,9 +259,9 @@ export type CompositeTypes<
     schema: keyof Database
   }
     ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
   ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-  ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-  : never
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "next": "15.1.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -10,6 +10,9 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        "dm-mono": ["DM Mono", "monospace"],
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
## **Summary of Changes**

Adds prompt creation operation to the front-end with functionality.

Depends on james-frontend

---

## **Related Issues or Feature Requests (if applicable)**

n/a
---

## **Steps to Test (if applicable)**

run npm run dev and try creating a prompt once logged in (click new button)

---

## **Screenshots (if applicable)**

<img width="1495" alt="Screenshot 2025-03-01 at 6 09 30 PM" src="https://github.com/user-attachments/assets/2c40d581-3f97-4ae7-8c7b-73b764ea124f" />

---

### **Checklist**

- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated any relevant documentation.
- [x] I have linked this PR to a related issue or feature request (if applicable).

---

### **Additional Notes**

re-worked supabase tables to support newer schema

schema now:
`prompts` is the root table
`prompt_versions` has a foreign key to prompts. these store the template (i.e. prompt content)
`run_history` has a foreign key to `prompt_versions`