### PR TITLE
fetch prompt versions and store prompt descriptions

### DIFF
--- a/web/app/api/prompts/route.ts
+++ b/web/app/api/prompts/route.ts
@@ -8,10 +8,62 @@ const supabase = createClient<Database>(
   process.env.SUPABASE_ANON_KEY ?? ""
 )
 
+export async function GET() {
+  try {
+    // First, get all prompts
+    const { data: prompts, error: promptsError } = await supabase
+      .from("prompts")
+      .select("*")
+
+    if (promptsError) {
+      console.error("Error fetching prompts:", promptsError)
+      return NextResponse.json(
+        { error: "Failed to fetch prompts" },
+        { status: 500 }
+      )
+    }
+
+    // Now get versions for each prompt
+    const promptsWithVersions = await Promise.all(
+      prompts.map(async (prompt) => {
+        const { data: versions, error: versionsError } = await supabase
+          .from("prompt_version")
+          .select("version")
+          .eq("prompt_id", prompt.id)
+          .order("created_at", { ascending: false })
+
+        if (versionsError) {
+          console.error(
+            `Error fetching versions for prompt ${prompt.id}:`,
+            versionsError
+          )
+          return {
+            ...prompt,
+            versions: [],
+          }
+        }
+
+        return {
+          ...prompt,
+          versions: versions.map((v) => v.version),
+        }
+      })
+    )
+
+    return NextResponse.json(promptsWithVersions)
+  } catch (error) {
+    console.error("Unexpected error:", error)
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    )
+  }
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json()
-    const { name, template, version, templateVariables } = body
+    const { name, description, template, version, templateVariables } = body
 
     // Validation
     if (!name || !template || !version) {
@@ -24,7 +76,7 @@ export async function POST(request: Request) {
     // First, create the prompt
     const { data: promptData, error: promptError } = await supabase
       .from("prompts")
-      .insert([{ name, template }])
+      .insert([{ name, description }])
       .select("id")
       .single()
 

--- a/web/app/prompts/new/page.client.tsx
+++ b/web/app/prompts/new/page.client.tsx
@@ -11,11 +11,13 @@ const NewPromptClient = () => {
   const [promptName, setPromptName] = useState<string>("Untitled")
   const [version, setVersion] = useState<string>("0.0.1")
   const [template, setTemplate] = useState<string>("")
+  const [description, setDescription] = useState<string>("")
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [errors, setErrors] = useState<{
     name?: string
     version?: string
     template?: string
+    description?: string
     general?: string
   }>({})
 
@@ -38,6 +40,10 @@ const NewPromptClient = () => {
 
     if (!version || !version.match(/^\d+\.\d+\.\d+$/)) {
       newErrors.version = "Version must be in format x.y.z (e.g. 0.0.1)"
+    }
+
+    if (!description || description.trim() === "") {
+      newErrors.description = "Description is required"
     }
 
     if (!template || template.trim() === "") {
@@ -68,6 +74,7 @@ const NewPromptClient = () => {
         body: JSON.stringify({
           name: promptName,
           template,
+          description,
           version,
           templateVariables,
         }),
@@ -174,6 +181,28 @@ const NewPromptClient = () => {
             </div>
             {errors.version && (
               <p className="text-red-500 text-sm mt-1">{errors.version}</p>
+            )}
+          </div>
+
+          <div className="flex flex-col">
+            <label className="block mb-1 text-gray-500 font-dm-mono font-medium">
+              Description
+            </label>
+            <div
+              className={`border-2 ${
+                errors.description ? "border-red-500" : "border-gray-200"
+              } focus-within:border-burnt-orange focus-within:ring-1 focus-within:ring-burnt-orange bg-cream`}
+            >
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="w-full p-2 outline-none border-none font-dm-mono bg-cream resize-y min-h-[42px]"
+                placeholder="e.g. What does this prompt do?"
+                rows={1}
+              />
+            </div>
+            {errors.description && (
+              <p className="text-red-500 text-sm mt-1">{errors.description}</p>
             )}
           </div>
 

--- a/web/app/prompts/page.client.tsx
+++ b/web/app/prompts/page.client.tsx
@@ -1,12 +1,21 @@
 "use client"
 
 import { Merriweather } from "next/font/google"
-import { PromptTemplate } from "@anyprompt/core"
 import PromptCard from "@/components/PromptCard"
 import { Plus } from "lucide-react"
 import Link from "next/link"
+
+type PromptWithVersions = {
+  id: string
+  name: string
+  description: string
+  created_at: string
+  updated_at: string
+  versions: string[]
+}
+
 interface PromptsPageClientProps {
-  prompts: PromptTemplate[]
+  prompts: PromptWithVersions[]
 }
 
 const merriweather = Merriweather({

--- a/web/app/prompts/page.tsx
+++ b/web/app/prompts/page.tsx
@@ -1,31 +1,18 @@
-import { createClient } from "@supabase/supabase-js"
-import { PromptTemplate, promptNameAndVersion } from "@anyprompt/core"
-
-import { Database } from "@/database.types"
 import PromptsPageClient from "./page.client"
 
-const supabase = createClient<Database>(
-  process.env.SUPABASE_URL ?? "",
-  process.env.SUPABASE_ANON_KEY ?? ""
-)
+async function getPromptsWithVersions() {
+  const res = await fetch(`http://localhost:3000/api/prompts`, {
+    cache: "no-store",
+  })
 
-async function selectPrompts() {
-  return supabase.from("prompts").select("*")
+  if (!res.ok) {
+    throw new Error("Failed to fetch prompts")
+  }
+
+  return res.json()
 }
 
 export default async function PromptsPage() {
-  const { data } = await selectPrompts()
-  const prompts: PromptTemplate[] =
-    data?.map((prompt) => {
-      // const [name, version] = promptNameAndVersion(prompt.id)
-      const [name, version] = ["test", "test"]
-      return {
-        id: prompt.id,
-        name,
-        version,
-        template: prompt.template,
-      }
-    }) ?? []
-
-  return <PromptsPageClient prompts={prompts} />
+  const prompts = await getPromptsWithVersions()
+  return <PromptsPageClient prompts={prompts ?? []} />
 }

--- a/web/components/PromptCard.tsx
+++ b/web/components/PromptCard.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React, { useState } from "react"
-import { PromptTemplate } from "@anyprompt/core"
 import { DM_Mono } from "next/font/google"
 import {
   Select,
@@ -12,8 +11,13 @@ import {
 } from "@/components/ui/select"
 import { Play } from "lucide-react"
 
-type Props = {
-  prompt: PromptTemplate
+type PromptCardProps = {
+  prompt: {
+    id: string
+    name: string
+    description: string
+    versions: string[]
+  }
 }
 
 const DMMono = DM_Mono({
@@ -26,18 +30,14 @@ const DMMonoBold = DM_Mono({
   subsets: ["latin"],
 })
 
-const versions = ["0.0.1", "0.0.2", "0.0.3"]
-
-const PromptCard = (props: Props) => {
+const PromptCard = ({ prompt }: PromptCardProps) => {
   const [version, setVersion] = useState("0.0.1")
-
-  console.log(props)
 
   return (
     <div className="bg-white rounded-lg p-6 shadow-sm flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <p className={`${DMMonoBold.className} text-lg text-navy`}>
-          {props.prompt.name}
+          {prompt.name}
         </p>
         <Select value={version} onValueChange={setVersion}>
           <SelectTrigger className="w-fit gap-x-2 rounded-none">
@@ -47,7 +47,7 @@ const PromptCard = (props: Props) => {
             />
           </SelectTrigger>
           <SelectContent>
-            {versions.map((version) => (
+            {prompt.versions.map((version) => (
               <SelectItem
                 key={version}
                 value={version}
@@ -60,7 +60,7 @@ const PromptCard = (props: Props) => {
         </Select>
       </div>
       <div className={`${DMMono.className} bg-cream p-4 text-sm text-gray-500`}>
-        {props.prompt.template}
+        {prompt.description}
       </div>
       <div className="flex items-center gap-4">
         <button className="flex items-center gap-2 font-bold bg-burnt-orange text-white px-4 py-2 hover:bg-burnt-orange-dark transition-all duration-300">

--- a/web/database.types.ts
+++ b/web/database.types.ts
@@ -50,23 +50,23 @@ export type Database = {
       prompts: {
         Row: {
           created_at: string
+          description: string | null
           id: string
           name: string
-          template: string
           updated_at: string | null
         }
         Insert: {
           created_at?: string
+          description?: string | null
           id?: string
           name: string
-          template: string
           updated_at?: string | null
         }
         Update: {
           created_at?: string
+          description?: string | null
           id?: string
           name?: string
-          template?: string
           updated_at?: string | null
         }
         Relationships: []


### PR DESCRIPTION
## **Summary of Changes**

- load prompt versions properly per the new schema
- show prompt versions properly in the web ui
- store description for prompt and don't show template in the web ui (some prompt templates will be very long so not super useful)

---

## **Related Issues or Feature Requests (if applicable)**

n/a

---

## **Steps to Test (if applicable)**

run `npm run dev` and try creating a new prompt and then seeing it in the prompts page

---

## **Screenshots (if applicable)**

<img width="1495" alt="Screenshot 2025-03-01 at 6 35 12 PM" src="https://github.com/user-attachments/assets/361299e9-290e-4003-8064-db3c07e99cac" />

<img width="1495" alt="Screenshot 2025-03-01 at 6 35 03 PM" src="https://github.com/user-attachments/assets/84ff61d8-68d8-4818-9db4-58b53808fc86" />

---

### **Checklist**

- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated any relevant documentation.
- [x] I have linked this PR to a related issue or feature request (if applicable).

---

### **Additional Notes**

n/a