### PR TITLE
feat: prompts page mostly done

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2025,6 +2025,41 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
@@ -2157,6 +2192,29 @@
       "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
@@ -10022,6 +10080,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anyprompt/core": "0.1.0",
+        "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-select": "^2.1.6",
         "@supabase/supabase-js": "^2.47.13",
         "class-variance-authority": "^0.7.1",

--- a/web/app/api/prompts/[id]/route.ts
+++ b/web/app/api/prompts/[id]/route.ts
@@ -1,0 +1,142 @@
+import { createClient } from "@supabase/supabase-js"
+import { Database } from "@/database.types"
+import { NextResponse } from "next/server"
+
+const supabase = createClient<Database>(
+  process.env.SUPABASE_URL ?? "",
+  process.env.SUPABASE_ANON_KEY ?? ""
+)
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const promptId = params.id
+
+    // First delete all versions of the prompt
+    const { error: versionsError } = await supabase
+      .from("prompt_version")
+      .delete()
+      .eq("prompt_id", promptId)
+
+    if (versionsError) {
+      console.error("Error deleting prompt versions:", versionsError)
+      return NextResponse.json(
+        { error: "Failed to delete prompt versions" },
+        { status: 500 }
+      )
+    }
+
+    // Then delete the prompt itself
+    const { error: promptError } = await supabase
+      .from("prompts")
+      .delete()
+      .eq("id", promptId)
+
+    if (promptError) {
+      console.error("Error deleting prompt:", promptError)
+      return NextResponse.json(
+        { error: "Failed to delete prompt" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Unexpected error:", error)
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    )
+  }
+}
+
+// We'll also need a PUT endpoint for updating prompts
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const promptId = params.id
+    const body = await request.json()
+    const { name, description, template, version, templateVariables } = body
+
+    // Validation
+    if (!name || !template || !version) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 }
+      )
+    }
+
+    // Update the prompt
+    const { error: promptError } = await supabase
+      .from("prompts")
+      .update({ name, description })
+      .eq("id", promptId)
+
+    if (promptError) {
+      console.error("Error updating prompt:", promptError)
+      return NextResponse.json(
+        { error: "Failed to update prompt" },
+        { status: 500 }
+      )
+    }
+
+    // Update or create the version
+    const { data: existingVersion } = await supabase
+      .from("prompt_version")
+      .select("id")
+      .eq("prompt_id", promptId)
+      .eq("version", version)
+      .single()
+
+    if (existingVersion) {
+      // Update existing version
+      const { error: versionError } = await supabase
+        .from("prompt_version")
+        .update({
+          prompt: template,
+          template_variables: templateVariables,
+        })
+        .eq("id", existingVersion.id)
+
+      if (versionError) {
+        console.error("Error updating prompt version:", versionError)
+        return NextResponse.json(
+          { error: "Failed to update prompt version" },
+          { status: 500 }
+        )
+      }
+    } else {
+      // Create new version
+      const { error: versionError } = await supabase
+        .from("prompt_version")
+        .insert([
+          {
+            prompt: template,
+            template_variables: templateVariables,
+            prompt_id: promptId,
+            version,
+          },
+        ])
+
+      if (versionError) {
+        console.error("Error creating prompt version:", versionError)
+        return NextResponse.json(
+          { error: "Failed to create prompt version" },
+          { status: 500 }
+        )
+      }
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Unexpected error:", error)
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    )
+  }
+}

--- a/web/app/api/prompts/[id]/versions/route.ts
+++ b/web/app/api/prompts/[id]/versions/route.ts
@@ -1,0 +1,72 @@
+import { createClient } from "@supabase/supabase-js"
+import { Database } from "@/database.types"
+import { NextResponse } from "next/server"
+
+const supabase = createClient<Database>(
+  process.env.SUPABASE_URL ?? "",
+  process.env.SUPABASE_ANON_KEY ?? ""
+)
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const promptId = params.id
+    const body = await request.json()
+    const { version, prompt, templateVariables } = body
+
+    // Validation
+    if (!version || !prompt) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 }
+      )
+    }
+
+    // Check if version already exists
+    const { data: existingVersion } = await supabase
+      .from("prompt_version")
+      .select("id")
+      .eq("prompt_id", promptId)
+      .eq("version", version)
+      .single()
+
+    if (existingVersion) {
+      return NextResponse.json(
+        { error: "Version already exists" },
+        { status: 400 }
+      )
+    }
+
+    // Create the new version
+    const { data, error } = await supabase
+      .from("prompt_version")
+      .insert([
+        {
+          prompt,
+          template_variables: templateVariables,
+          prompt_id: promptId,
+          version,
+        },
+      ])
+      .select()
+      .single()
+
+    if (error) {
+      console.error("Error creating prompt version:", error)
+      return NextResponse.json(
+        { error: "Failed to create prompt version" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error("Unexpected error:", error)
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    )
+  }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css"
 import Header from "@/components/Header"
 import Sidebar from "@/components/Sidebar"
 import { dmMono, merriweather } from "./fonts"
+import { Toaster } from "sonner"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -37,6 +38,7 @@ export default function RootLayout({
             <main className="flex-1">{children}</main>
           </div>
         </div>
+        <Toaster position="top-right" />
       </body>
     </html>
   )

--- a/web/app/prompts/[id]/components/NewVersionDialog.tsx
+++ b/web/app/prompts/[id]/components/NewVersionDialog.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import React, { useState } from "react"
+import { Loader2 } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface NewVersionDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onCreateVersion: (version: string) => Promise<void>
+  currentVersion: string
+  isLoading: boolean
+}
+
+export default function NewVersionDialog({
+  isOpen,
+  onClose,
+  onCreateVersion,
+  currentVersion,
+  isLoading,
+}: NewVersionDialogProps) {
+  // Generate a suggested new version based on current version
+  const generateSuggestedVersion = () => {
+    const versionParts = currentVersion.split(".").map(Number)
+    versionParts[2] += 1 // Increment the patch version
+    return versionParts.join(".")
+  }
+
+  const [newVersion, setNewVersion] = useState<string>(
+    generateSuggestedVersion()
+  )
+  const [error, setError] = useState<string>("")
+
+  // Handle form submission
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // Validate version format
+    if (!newVersion || !newVersion.match(/^\d+\.\d+\.\d+$/)) {
+      setError("Version must be in format x.y.z (e.g. 0.0.1)")
+      return
+    }
+
+    await onCreateVersion(newVersion)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="p-4">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-medium">
+            Create New Version
+          </DialogTitle>
+          <DialogDescription className="text-gray-600">
+            Enter a version number for the new prompt version.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+          <div className="flex flex-col">
+            <label className="block mb-1 text-gray-500 font-dm-mono font-medium">
+              Version Number
+            </label>
+            <input
+              type="text"
+              value={newVersion}
+              onChange={(e) => setNewVersion(e.target.value)}
+              className="w-full p-2 outline-none border-2 border-gray-200 focus:border-burnt-orange focus:ring-1 focus:ring-burnt-orange bg-cream font-dm-mono"
+              placeholder="e.g. 0.0.2"
+            />
+            {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+          </div>
+
+          <DialogFooter className="pt-4 flex justify-end gap-x-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="border-gray-300 bg-white text-gray-800 hover:bg-gray-100 px-4 py-2 rounded-none border"
+              disabled={isLoading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-burnt-orange px-4 py-2 hover:bg-burnt-orange-dark text-white rounded-none flex items-center justify-center gap-2"
+              disabled={isLoading}
+            >
+              {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+              Create Version
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/app/prompts/[id]/components/PromptEditor.tsx
+++ b/web/app/prompts/[id]/components/PromptEditor.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import React from "react"
+import VersionSelector from "./VersionSelector"
+import { Database } from "@/database.types"
+
+interface PromptEditorProps {
+  promptName: string
+  version: string
+  versions: Database["public"]["Tables"]["prompt_version"]["Row"][]
+  description: string
+  template: string
+  errors: {
+    description?: string
+    template?: string
+  }
+  onDescriptionChange: (value: string) => void
+  onTemplateChange: (value: string) => void
+  onVersionChange: (value: string) => void
+}
+
+export default function PromptEditor({
+  promptName,
+  description,
+  template,
+  errors,
+  onDescriptionChange,
+  onTemplateChange,
+  version,
+  versions,
+  onVersionChange,
+}: PromptEditorProps) {
+  // Extract template variables from the template
+  const extractTemplateVariables = (templateText: string): string[] => {
+    const regex = /{{([^{}]+)}}/g
+    const matches = [...templateText.matchAll(regex)]
+    const variables = matches.map((match) => match[1].trim())
+    // Remove duplicates
+    return [...new Set(variables)]
+  }
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <div>
+        <p className="text-gray-500 font-dm-mono font-medium">Name</p>
+        <p className="text-2xl font-dm-mono font-medium">{promptName}</p>
+      </div>
+
+      <VersionSelector
+        version={version}
+        versions={versions}
+        onVersionChange={onVersionChange}
+      />
+
+      <div className="flex flex-col">
+        <label className="block mb-1 text-gray-500 font-dm-mono font-medium">
+          Description
+        </label>
+        <div
+          className={`border-2 ${
+            errors.description ? "border-red-500" : "border-gray-200"
+          } focus-within:border-burnt-orange focus-within:ring-1 focus-within:ring-burnt-orange bg-cream`}
+        >
+          <textarea
+            value={description}
+            onChange={(e) => onDescriptionChange(e.target.value)}
+            className="w-full p-2 outline-none border-none font-dm-mono bg-cream resize-y min-h-[42px]"
+            placeholder="e.g. What does this prompt do?"
+            rows={1}
+          />
+        </div>
+        {errors.description && (
+          <p className="text-red-500 text-sm mt-1">{errors.description}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col flex-grow">
+        <label className="block mb-1 text-gray-500 font-dm-mono font-medium">
+          Template
+        </label>
+        <div
+          className={`border-2 ${
+            errors.template ? "border-red-500" : "border-gray-200"
+          } focus-within:border-burnt-orange focus-within:ring-1 focus-within:ring-burnt-orange bg-cream`}
+        >
+          <textarea
+            value={template}
+            onChange={(e) => onTemplateChange(e.target.value)}
+            className="w-full p-2 outline-none border-none font-dm-mono bg-cream resize-y min-h-[200px]"
+            placeholder='e.g. Always respond "hello world". Use {{variable}} for template variables.'
+            rows={10}
+          />
+        </div>
+        {errors.template && (
+          <p className="text-red-500 text-sm mt-1">{errors.template}</p>
+        )}
+
+        {template && (
+          <div className="mt-2">
+            <h3 className="text-sm font-medium text-gray-600">
+              Template Variables Detected:
+            </h3>
+            <div className="mt-1 flex flex-wrap gap-2">
+              {extractTemplateVariables(template).length > 0 ? (
+                extractTemplateVariables(template).map((variable, idx) => (
+                  <span
+                    key={idx}
+                    className="px-2 py-1 bg-gray-100 text-gray-700 text-sm rounded-md"
+                  >
+                    {variable}
+                  </span>
+                ))
+              ) : (
+                <span className="text-sm text-gray-500">
+                  No variables detected. Use {`{{variable_name}}`} syntax.
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/app/prompts/[id]/components/PromptHeader.tsx
+++ b/web/app/prompts/[id]/components/PromptHeader.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import { merriweather } from "@/app/fonts"
+import Link from "next/link"
+import { X, Loader2 } from "lucide-react"
+import React from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { toast } from "sonner"
+import { useRouter } from "next/navigation"
+
+interface PromptHeaderProps {
+  id: string
+  promptName: string
+  version: string
+  template: string
+  description: string
+  isLoading: boolean
+  onSave: () => Promise<void>
+  onNewVersion: () => void
+}
+
+export default function PromptHeader({
+  id,
+  promptName,
+  version,
+  template,
+  description,
+  isLoading,
+  onSave,
+  onNewVersion,
+}: PromptHeaderProps) {
+  const router = useRouter()
+  const [isDeleting, setIsDeleting] = React.useState<boolean>(false)
+  const [isDuplicating, setIsDuplicating] = React.useState<boolean>(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(false)
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      const response = await fetch(`/api/prompts/${id}`, {
+        method: "DELETE",
+      })
+
+      if (response.ok) {
+        toast.success("Prompt deleted successfully")
+        router.push("/prompts")
+      } else {
+        const data = await response.json()
+        throw new Error(data.error || "Failed to delete prompt")
+      }
+    } catch (error) {
+      console.error("Error deleting prompt:", error)
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete prompt"
+      )
+    } finally {
+      setIsDeleting(false)
+      setDeleteDialogOpen(false)
+    }
+  }
+
+  const handleDuplicate = async () => {
+    setIsDuplicating(true)
+    try {
+      const response = await fetch("/api/prompts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: `${promptName} (Copy)`,
+          template,
+          description,
+          version,
+          templateVariables: extractTemplateVariables(template),
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to duplicate prompt")
+      }
+
+      toast.success("Prompt duplicated successfully")
+      // Navigate to the new prompt
+      router.push(`/prompts/${data.id}`)
+    } catch (error) {
+      console.error("Error duplicating prompt:", error)
+      toast.error(
+        error instanceof Error ? error.message : "Failed to duplicate prompt"
+      )
+    } finally {
+      setIsDuplicating(false)
+    }
+  }
+
+  // Helper function to extract template variables
+  const extractTemplateVariables = (templateText: string): string[] => {
+    const regex = /{{([^{}]+)}}/g
+    const matches = [...templateText.matchAll(regex)]
+    const variables = matches.map((match) => match[1].trim())
+    return [...new Set(variables)]
+  }
+
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div className="flex gap-2 text-2xl font-bold">
+        <p className={`${merriweather.className}`}>Prompts</p>
+        <p className="font-mono">/</p>
+        <p className="font-mono font-normal">
+          {promptName}@{version}
+        </p>
+      </div>
+      <div className="flex gap-2 items-center">
+        <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <DialogTrigger asChild>
+            <button className="px-4 py-2 bg-white hover:bg-gray-100 text-gray-800 border border-gray-300 transition-all duration-300">
+              Delete
+            </button>
+          </DialogTrigger>
+          <DialogContent className="p-4">
+            <DialogHeader>
+              <DialogTitle className="text-lg font-medium">
+                Delete Prompt
+              </DialogTitle>
+              <DialogDescription className="text-gray-600">
+                This action cannot be undone. This will permanently delete the
+                prompt and all its versions.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="p-4 flex justify-end gap-x-2">
+              <button
+                onClick={() => setDeleteDialogOpen(false)}
+                className="border-gray-300 bg-white text-gray-800 hover:bg-gray-100 px-4 py-2 rounded-none border"
+                disabled={isDeleting}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                className="bg-red-600 px-4 py-2 hover:bg-red-700 text-white rounded-none flex items-center justify-center gap-2"
+                disabled={isDeleting}
+              >
+                {isDeleting && <Loader2 className="h-4 w-4 animate-spin" />}
+                Delete
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <button
+          onClick={handleDuplicate}
+          className="px-4 py-2 bg-white hover:bg-gray-100 text-gray-800 border border-gray-300 transition-all duration-300 flex items-center justify-center gap-2"
+          disabled={isDuplicating}
+        >
+          {isDuplicating && <Loader2 className="h-4 w-4 animate-spin" />}
+          Duplicate
+        </button>
+        <button
+          onClick={onNewVersion}
+          className="px-4 py-2 bg-white hover:bg-gray-100 text-gray-800 border border-gray-300 transition-all duration-300 flex items-center justify-center gap-2"
+        >
+          New Version
+        </button>
+        <button
+          onClick={onSave}
+          disabled={isLoading}
+          className={`flex items-center gap-2 justify-center font-bold ${
+            isLoading
+              ? "bg-gray-400"
+              : "bg-burnt-orange hover:bg-burnt-orange-dark"
+          } text-white px-4 py-2 transition-all duration-300`}
+        >
+          {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+          <p className="font-bold">{isLoading ? "Saving..." : "Save"}</p>
+        </button>
+        <Link href="/prompts" className="px-2">
+          <X />
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/web/app/prompts/[id]/components/RunHistory.tsx
+++ b/web/app/prompts/[id]/components/RunHistory.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import React from "react"
+import { Play } from "lucide-react"
+
+interface RunHistoryProps {
+  runHistory: any[]
+  onRun: () => void
+}
+
+export default function RunHistory({ runHistory, onRun }: RunHistoryProps) {
+  return (
+    <div className="flex flex-col">
+      <div className="mb-2 text-gray-500 font-dm-mono font-medium">
+        Run history
+      </div>
+      <div className="flex flex-col gap-2 border-2 border-dashed border-gray-200 p-4 flex-grow">
+        <div className="flex justify-between items-center">
+          <select className="border-2 border-gray-200 p-1 focus:border-burnt-orange focus:ring-1 focus:ring-burnt-orange outline-none font-dm-mono">
+            {runHistory.length > 0 ? (
+              runHistory.map((run) => (
+                <option key={run.id} value={run.id}>
+                  {run.model} {new Date(run.created_at).toLocaleString()}
+                </option>
+              ))
+            ) : (
+              <option className="text-gray-400">No runs to show</option>
+            )}
+          </select>
+          <button
+            onClick={onRun}
+            className="flex items-center gap-2 font-bold bg-burnt-orange text-white px-4 py-2 hover:bg-burnt-orange-dark transition-all duration-300"
+          >
+            <Play className="w-4 h-4 text-white" fill="white" />
+            <p className="font-bold">Run</p>
+          </button>
+        </div>
+
+        {runHistory.length > 0 ? (
+          <div className="mt-4 border-t pt-4">
+            <div className="mb-4">
+              <div className="border-l-4 border-orange-500 pl-2 mb-2">
+                <h3 className="text-sm font-medium text-gray-600">User</h3>
+                <p className="text-sm">Summarize the following email...</p>
+                <p className="text-sm">EMAIL:</p>
+              </div>
+
+              <div className="border-l-4 border-blue-500 pl-2">
+                <h3 className="text-sm font-medium text-gray-600">Assistant</h3>
+                <p className="text-sm">
+                  Sure! Please provide the content of the email you&apos;d like
+                  me to summarize.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="border-2 border-dashed border-gray-300 p-4 flex-grow mt-2 flex items-center justify-center text-gray-400">
+            Run results will appear here
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/app/prompts/[id]/components/VersionSelector.tsx
+++ b/web/app/prompts/[id]/components/VersionSelector.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import React from "react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Database } from "@/database.types"
+
+interface VersionSelectorProps {
+  version: string
+  versions: Database["public"]["Tables"]["prompt_version"]["Row"][]
+  onVersionChange: (version: string) => void
+}
+
+export default function VersionSelector({
+  version,
+  versions,
+  onVersionChange,
+}: VersionSelectorProps) {
+  return (
+    <div className="flex flex-col">
+      <label className="block mb-1 text-gray-500 font-dm-mono font-medium">
+        Version
+      </label>
+      <Select value={version} onValueChange={onVersionChange}>
+        <SelectTrigger className="w-full bg-cream border-2 border-gray-200 focus:border-burnt-orange focus:ring-1 focus:ring-burnt-orange rounded-none">
+          <SelectValue placeholder="Select a version" />
+        </SelectTrigger>
+        <SelectContent className="rounded-none">
+          {versions.map((v) => (
+            <SelectItem key={v.id} value={v.version as string}>
+              {v.version}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/web/app/prompts/[id]/page.client.tsx
+++ b/web/app/prompts/[id]/page.client.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import React, { useState, useEffect } from "react"
+import { toast } from "sonner"
+import { Database } from "@/database.types"
+
+// Import our new components
+import PromptHeader from "./components/PromptHeader"
+import PromptEditor from "./components/PromptEditor"
+import RunHistory from "./components/RunHistory"
+import NewVersionDialog from "./components/NewVersionDialog"
+
+interface PromptClientProps {
+  id: string
+  prompt: Database["public"]["Tables"]["prompts"]["Row"]
+  versions: Database["public"]["Tables"]["prompt_version"]["Row"][]
+}
+
+const PromptClient = ({ id, prompt, versions }: PromptClientProps) => {
+  const [promptName, setPromptName] = useState<string>(prompt.name)
+  const [version, setVersion] = useState<string>(versions[0].version as string)
+  const [template, setTemplate] = useState<string>(versions[0].prompt as string)
+  const [description, setDescription] = useState<string>(
+    prompt.description || ""
+  )
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isCreatingVersion, setIsCreatingVersion] = useState<boolean>(false)
+  const [errors, setErrors] = useState<{
+    name?: string
+    version?: string
+    template?: string
+    description?: string
+    general?: string
+  }>({})
+  const [runHistory, setRunHistory] = useState<any[]>([])
+  const [newVersionDialogOpen, setNewVersionDialogOpen] =
+    useState<boolean>(false)
+
+  // Extract template variables from the template
+  const extractTemplateVariables = (templateText: string): string[] => {
+    const regex = /{{([^{}]+)}}/g
+    const matches = [...templateText.matchAll(regex)]
+    const variables = matches.map((match) => match[1].trim())
+    // Remove duplicates
+    return [...new Set(variables)]
+  }
+
+  // Fetch run history
+  useEffect(() => {
+    const fetchRunHistory = async () => {
+      try {
+        const response = await fetch(`/api/prompts/${id}/runs`)
+        if (response.ok) {
+          const data = await response.json()
+          setRunHistory(data)
+        }
+      } catch (error) {
+        console.error("Error fetching run history:", error)
+      }
+    }
+
+    fetchRunHistory()
+  }, [id])
+
+  // Validate form fields
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {}
+
+    if (!promptName || promptName.trim() === "") {
+      newErrors.name = "Prompt name is required"
+    }
+
+    if (!version || !version.match(/^\d+\.\d+\.\d+$/)) {
+      newErrors.version = "Version must be in format x.y.z (e.g. 0.0.1)"
+    }
+
+    if (!template || template.trim() === "") {
+      newErrors.template = "Template is required"
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async () => {
+    if (!validateForm()) {
+      return
+    }
+
+    setIsLoading(true)
+
+    try {
+      // Extract template variables
+      const templateVariables = extractTemplateVariables(template)
+
+      // Call API route to update prompt
+      const response = await fetch(`/api/prompts/${id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: promptName,
+          template,
+          description,
+          version,
+          templateVariables,
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to save prompt")
+      }
+
+      // Show success toast
+      toast.success("Prompt saved successfully")
+    } catch (error) {
+      console.error("Error saving prompt:", error)
+      setErrors({
+        general:
+          error instanceof Error
+            ? error.message
+            : "Failed to save prompt. Please try again.",
+      })
+      // Show error toast
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save prompt"
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleRun = async () => {
+    // TODO: Implement run functionality
+    console.log("Running prompt:", { name: promptName, version, template })
+  }
+
+  // Handle version change
+  const handleVersionChange = (newVersion: string) => {
+    // Find the selected version from versions array
+    const selectedVersion = versions.find((v) => v.version === newVersion)
+
+    if (selectedVersion) {
+      setVersion(newVersion)
+      setTemplate(selectedVersion.prompt as string)
+    }
+  }
+
+  const handleCreateNewVersion = async (newVersion: string) => {
+    setIsCreatingVersion(true)
+
+    try {
+      const response = await fetch(`/api/prompts/${id}/versions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          version: newVersion,
+          prompt: template,
+          templateVariables: extractTemplateVariables(template),
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to create new version")
+      }
+
+      toast.success(`Version ${newVersion} created successfully`)
+      // Close the dialog and refresh to show the new version
+      setNewVersionDialogOpen(false)
+      window.location.reload()
+    } catch (error) {
+      console.error("Error creating new version:", error)
+      setErrors({
+        general:
+          error instanceof Error
+            ? error.message
+            : "Failed to create new version. Please try again.",
+      })
+      toast.error(
+        error instanceof Error ? error.message : "Failed to create new version"
+      )
+    } finally {
+      setIsCreatingVersion(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <PromptHeader
+        id={id}
+        promptName={promptName}
+        version={version}
+        template={template}
+        description={description}
+        isLoading={isLoading}
+        onSave={handleSave}
+        onNewVersion={() => setNewVersionDialogOpen(true)}
+      />
+
+      {errors.general && (
+        <div className="p-3 mb-4 text-red-700 bg-red-100 border border-red-300 rounded">
+          {errors.general}
+        </div>
+      )}
+
+      <div className="grid grid-cols-3 gap-4 flex-grow">
+        <div className="col-span-2 flex flex-col space-y-4">
+          <PromptEditor
+            promptName={promptName}
+            description={description}
+            template={template}
+            errors={{
+              description: errors.description,
+              template: errors.template,
+            }}
+            onDescriptionChange={setDescription}
+            onTemplateChange={setTemplate}
+            version={version}
+            versions={versions}
+            onVersionChange={handleVersionChange}
+          />
+        </div>
+
+        <div className="col-span-1">
+          <RunHistory runHistory={runHistory} onRun={handleRun} />
+        </div>
+      </div>
+
+      <NewVersionDialog
+        isOpen={newVersionDialogOpen}
+        onClose={() => setNewVersionDialogOpen(false)}
+        onCreateVersion={handleCreateNewVersion}
+        currentVersion={version}
+        isLoading={isCreatingVersion}
+      />
+    </div>
+  )
+}
+
+export default PromptClient

--- a/web/app/prompts/[id]/page.tsx
+++ b/web/app/prompts/[id]/page.tsx
@@ -1,0 +1,49 @@
+import { createClient } from "@supabase/supabase-js"
+import { redirect } from "next/navigation"
+import PromptClient from "./page.client"
+import { Database } from "@/database.types"
+
+interface PageParams {
+  params: {
+    id: string
+  }
+}
+
+export default async function PromptPage({ params }: PageParams) {
+  // Extract and validate id from params - no longer accessing it directly multiple times
+  const id = params.id
+
+  const supabase = createClient<Database>(
+    process.env.SUPABASE_URL ?? "",
+    process.env.SUPABASE_ANON_KEY ?? ""
+  )
+
+  // Fetch the prompt data with the validated id
+  const { data: prompt, error: promptError } = await supabase
+    .from("prompts")
+    .select("*")
+    .eq("id", id)
+    .single()
+
+  const { data: versions, error: versionsError } = await supabase
+    .from("prompt_version")
+    .select("*")
+    .eq("prompt_id", id)
+    .order("created_at", { ascending: false })
+
+  if (promptError || !prompt) {
+    console.error("Error fetching prompt:", promptError)
+    return redirect("/prompts")
+  }
+
+  if (versionsError || !versions) {
+    console.error("Error fetching versions:", versionsError)
+    return redirect("/prompts")
+  }
+
+  return (
+    <div className="container mx-auto px-8 py-6">
+      <PromptClient id={id} prompt={prompt} versions={versions ?? []} />
+    </div>
+  )
+}

--- a/web/components/PromptCard.tsx
+++ b/web/components/PromptCard.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Play } from "lucide-react"
+import Link from "next/link"
 
 type PromptCardProps = {
   prompt: {
@@ -67,9 +68,12 @@ const PromptCard = ({ prompt }: PromptCardProps) => {
           <Play className="w-4 h-4 text-white" fill="white" />
           <p className={`${DMMono.className} font-bold`}>Run</p>
         </button>
-        <button className="flex items-center font-bold gap-2 border px-4 py-2 hover:bg-[#F5F5F5] transition-all duration-300">
+        <Link
+          href={`/prompts/${prompt.id}`}
+          className="flex items-center font-bold gap-2 border px-4 py-2 hover:bg-[#F5F5F5] transition-all duration-300"
+        >
           Edit
-        </button>
+        </Link>
       </div>
     </div>
   )

--- a/web/components/ui/dialog.tsx
+++ b/web/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-none",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-none opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@anyprompt/core": "0.1.0",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-select": "^2.1.6",
     "@supabase/supabase-js": "^2.47.13",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## **Summary of Changes**

- wrap up CRUD functionality for prompts/prompt versions. specifically, update and delete operations
- add prompt page
- add dialog + toast
- ui/ux can be cleaned up slightly. E.g. description edits will edit the entire prompt and can be debated whether each version should have a description as well (e.g. if we want to track diffs/motivations between versions)

---

## **Related Issues or Feature Requests (if applicable)**

n/a

---

## **Steps to Test (if applicable)**

run `npm run dev` and mess around with the page

---

## **Screenshots (if applicable)**

creating and editing prompt versions

https://github.com/user-attachments/assets/93e254ec-d8e3-40cf-9c07-4dfb05512f30

deleting prompts/creating duplicates

https://github.com/user-attachments/assets/0235ead6-dc1c-48ba-bf1c-310943305dc4

---

### **Checklist**

- [x] I have performed a self-review of my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated any relevant documentation.
- [x] I have linked this PR to a related issue or feature request (if applicable).

---

### **Additional Notes**

- should probably make version naming more relaxed. e.g. one version works better with llama 3.7 and another with gpt 4.5
- ui/ux can be improved in follow-up branches
- once auth is finished, queries/mutations should update along with tables in supabase with RLS
- components created in the [id] route can be re-used in other places. a follow-up PR will address this and make them more general purpose